### PR TITLE
Derived streams

### DIFF
--- a/moztelemetry/heka_message_parser.py
+++ b/moztelemetry/heka_message_parser.py
@@ -27,7 +27,10 @@ def parse_heka_message(message, boundary_bytes=None):
 
 
 def _parse_heka_record(record):
-    result = json.loads(record.message.payload)
+    if record.message.payload:
+        result = json.loads(record.message.payload)
+    else:
+        result = {}
     result["meta"] = {
         # TODO: uuid, logger, severity, env_version, pid
         "Timestamp": record.message.timestamp,

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -222,10 +222,7 @@ def get_records(sc, source_name, **kwargs):
         return sc.parallelize(ranges, len(ranges)).flatMap(_read_v4_range)
 
 def _list_s3_filenames(bucket, prefix, schema):
-    filenames = []
-    for k in s3u.list_heka_partitions(bucket, prefix, schema=schema):
-        filenames.append(k.name)
-    return filenames
+    return [k.name for k in s3u.list_heka_partitions(bucket, prefix, schema=schema)]
 
 def _filter_to_schema(schema, filter_args):
     new_schema = {"version": 1, "dimensions": []}

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -192,7 +192,13 @@ def get_records(sc, source_name, **kwargs):
     filter_args = {}
     field_names = [f["field_name"] for f in schema["dimensions"]]
     for field_name in field_names:
-        filter_args[field_name] = kwargs.pop(field_name, None)
+        field_filter = kwargs.pop(field_name, None)
+        # Special case for compatibility with get_pings:
+        #   If we get a filter parameter that is a tuple of length 2, treat it
+        #   as a min/max filter instead of a list of allowed values.
+        if isinstance(field_filter, tuple) and len(field_filter) == 2:
+            field_filter = {"min": field_filter[0], "max": field_filter[1]}
+        filter_args[field_name] = field_filter
 
     if kwargs:
         raise TypeError("Unexpected **kwargs {}".format(repr(kwargs)))

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -233,7 +233,7 @@ def _filter_to_schema(schema, filter_args):
         }
         if dim["field_name"] in filter_args:
             new_filter["allowed_values"] = filter_args[dim["field_name"]]
-
+        new_schema["dimensions"].append(new_filter)
     return TelemetrySchema(new_schema)
 
 

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -159,6 +159,7 @@ def get_data_sources():
         return {}
 
 def get_source_schema(source_name):
+    global _sources
     if _sources is None:
         _sources = get_data_sources()
 
@@ -202,8 +203,8 @@ def get_records(sc, source_name, **kwargs):
     # TODO: cache the buckets, or at least recognize the ones we already have
     #       handles to (_bucket_* vars)
     bucket = _bucket_v4 # TODO: bucket = _conn.get_bucket(bucket_name, validate=False)
-    # TODO: list S3
-    files = _list_s3_filenames(bucket, bucket_prefix, _filter_to_schema(schema, filter_args))
+    filter_schema = _filter_to_schema(schema, filter_args)
+    files = _list_s3_filenames(bucket, bucket_prefix, filter_schema)
 
     if files and fraction != 1.0:
         sample = random.choice(files, size=len(files)*fraction, replace=False)

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -181,6 +181,8 @@ def get_records(sc, source_name, **kwargs):
 
     bucket_name = _sources[source_name]["bucket"]
     bucket_prefix = _sources[source_name]["prefix"]
+    if bucket_prefix[-1] != "/":
+        bucket_prefix = bucket_prefix + "/"
 
     fraction = kwargs.pop("fraction", 1.0)
     if fraction < 0 or fraction > 1:

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -150,7 +150,7 @@ def get_one_ping_per_client(pings):
                     reduceByKey(lambda p1, p2: p1).\
                     map(lambda p: p[1])
 
-def get_data_sources():
+def _get_data_sources():
     try:
         key = _bucket_meta.get_key("sources.json")
         sources = key.get_contents_as_string()
@@ -158,10 +158,10 @@ def get_data_sources():
     except ssl.SSLError:
         return {}
 
-def get_source_schema(source_name):
+def _get_source_schema(source_name):
     global _sources
     if _sources is None:
-        _sources = get_data_sources()
+        _sources = _get_data_sources()
 
     if source_name not in _sources:
         raise ValueError("Unknown data source: {}. Known sources: [{}].".format(source_name, ", ".join(sorted(_sources.keys()))))
@@ -176,7 +176,7 @@ def get_source_schema(source_name):
     return _sources[source_name]["schema"]
 
 def get_records(sc, source_name, **kwargs):
-    schema = get_source_schema(source_name)
+    schema = _get_source_schema(source_name)
     if schema is None:
         raise ValueError("Error getting schema for {}".format(source_name))
 

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -162,7 +162,7 @@ def get_records(sc, source_name, **kwargs):
 
     Filtering criteria should be specified using the TelemetrySchema approach:
     Range filter: submissionDate={"min": "20150901", "max": "20150908"}
-                     or submissionDate=("20150901", "20150908")
+                  or submissionDate=("20150901", "20150908")
     List filter: appUpdateChannel=["nightly", "aurora", "beta"]
     Value filter: docType="main"
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class FetchExternal(setuptools.command.install.install):
 
 setup(cmdclass={'install': FetchExternal},
       name='python_moztelemetry',
-      version='0.3.6.3',
+      version='0.3.6.4',
       author='Roberto Agostino Vitillo',
       author_email='rvitillo@mozilla.com',
       description='Spark bindings for Mozilla Telemetry',


### PR DESCRIPTION
Add a `get_records` function that can be used to fetch (and filter) data for derived streams using the Pipeline metadata.