### PR TITLE
Skip null field filters.

### DIFF
--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -184,6 +184,8 @@ def get_records(sc, source_name, **kwargs):
     field_names = [f["field_name"] for f in schema["dimensions"]]
     for field_name in field_names:
         field_filter = kwargs.pop(field_name, None)
+        if field_filter is None:
+            continue
         # Special case for compatibility with get_pings:
         #   If we get a filter parameter that is a tuple of length 2, treat it
         #   as a min/max filter instead of a list of allowed values.


### PR DESCRIPTION
We don't want to default to "allowed_values" = null, so we skip
un-set field filters. This means you don't have to specify a value
for every available field.