### PR TITLE
Skip bytes hackishly

### DIFF
--- a/moztelemetry/heka_message_parser.py
+++ b/moztelemetry/heka_message_parser.py
@@ -42,7 +42,9 @@ def _parse_heka_record(record):
         name = field.name.split('.')
         value = field.value_string
         if field.value_type == 1:
-            value = field.value_bytes
+            # TODO: handle bytes in a way that doesn't cause problems with JSON
+            # value = field.value_bytes
+            continue
         elif field.value_type == 2:
             value = field.value_integer
         elif field.value_type == 3:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ class FetchExternal(setuptools.command.install.install):
 
 setup(cmdclass={'install': FetchExternal},
       name='python_moztelemetry',
-      version='0.3.7.3',
+      version='0.3.7.5',
       author='Roberto Agostino Vitillo',
       author_email='rvitillo@mozilla.com',
       description='Spark bindings for Mozilla Telemetry',


### PR DESCRIPTION
Temporary workaround for problems caused by "bytes" fields (in the Telemetry case, it is the `submission` field containing gzipped bytes).