### PR TITLE
Handle case of passing "*" as an arg to get_pings()

### DIFF
--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -349,6 +349,8 @@ def _get_filenames_v2(**kwargs):
         tk = translate.get(k, None)
         if not tk:
             raise ValueError("Invalid query attribute name specified: {}".format(k))
+        if isinstance(v, basestring) and v == "*":
+            v = None
         query[tk] = v
 
     sdb = SDB("telemetry_v2")
@@ -369,6 +371,8 @@ def _get_filenames_v4(**kwargs):
         tk = translate.get(k, None)
         if not tk:
             raise ValueError("Invalid query attribute name specified: {}".format(k))
+        if isinstance(v, basestring) and v == "*":
+            v = None
         query[tk] = v
 
     sdb = SDB("telemetry_v4")

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -362,7 +362,7 @@ def _get_filenames_v2(**kwargs):
         tk = translate.get(k, None)
         if not tk:
             raise ValueError("Invalid query attribute name specified: {}".format(k))
-        if isinstance(v, basestring) and v == "*":
+        if v == "*":
             v = None
         query[tk] = v
 
@@ -384,7 +384,7 @@ def _get_filenames_v4(**kwargs):
         tk = translate.get(k, None)
         if not tk:
             raise ValueError("Invalid query attribute name specified: {}".format(k))
-        if isinstance(v, basestring) and v == "*":
+        if v == "*":
             v = None
         query[tk] = v
 


### PR DESCRIPTION
The telemetry schema uses `"*"` as a wildcard, to mean "allow all values for that field". When this is passed to `get_pings` it should be interpreted as "match any value" but it is treated as "match the string `'*'`".

This can be fixed by replacing `"*"` with `None` right before calling `SDB.query`.