### PR TITLE
Make get_pings_properties return all subhistograms for a keyedHistogram with missing key

### DIFF
--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -457,9 +457,10 @@ def _get_ping_properties(ping, paths, only_median, with_processes,
                     kh_histograms = {}
                     for kh_key in kh_keys:
                         props = _get_merged_histograms(cursor, kh_key,
-                                                    path + [kh_key],
-                                                    with_processes, histograms_url,
-                                                    additional_histograms)
+                                                       path + [kh_key],
+                                                       with_processes,
+                                                       histograms_url,
+                                                       additional_histograms)
                         for k, v in props.iteritems():
                             kh_histograms[k] = v.get_value(only_median) if v else None
 


### PR DESCRIPTION
If one of the paths passed to `get_pings_properties` points to the name of a keyedHistogram without including an actual key, return a dict containing subhistograms for all available keys for that keyedHistogram.

As far as I can tell, the only thing this could potentially break is if something depends on catching the error thrown at https://github.com/mozilla/python_moztelemetry/blob/master/moztelemetry/spark.py#L484, although I'm guessing this would be unlikely.