### PR TITLE
Fix retrieving keyed histograms missing keys

### DIFF
--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -457,7 +457,10 @@ def _get_ping_properties(ping, paths, only_median, with_processes,
                 # Include histograms for all available keys.
                 # These are returned as a subdict mapped from the property_name.
                 try:
-                    kh_keys = cursor["keyedHistograms"][path[1]].keys()
+                    kh_keys = set(cursor["keyedHistograms"][path[1]].keys())
+                    if isinstance(cursor, dict):
+                        for payload in cursor.get("childPayloads", []):
+                            kh_keys.update(payload["keyedHistograms"][path[1]].keys())
                 except:
                     result[property_name] = None
                     continue


### PR DESCRIPTION
When keyed histograms have keys in the child that don't exist in the parent, `get_ping_properties` doesn't return those keys.

Keys in keyed histograms in the child payloads are only returned if the keyed histogram in the parent process has those keys as well.

Here's a sample with the new hello world notebook: https://gist.github.com/Uberi/7d607a6035116f2f8c09. The second half was taking really long, so I interrupted it after running all the code that can call or indirectly access `_get_ping_properties` and `_get_merged_histograms`.