### PR TITLE
Fix threading issue with SimpleDB

### DIFF
--- a/moztelemetry/filter_service.py
+++ b/moztelemetry/filter_service.py
@@ -71,6 +71,17 @@ class SDB:
         for domain_name in domains:
             self._domains[domain_name[len(self.prefix) + 1:]] = self.sdb.get_domain(domain_name)
 
+    def __del__(self):
+        # We terminate rather than closing because if we're destroying the SDB object,
+        # then the workers' results won't matter anyways.
+        # Although this is called automatically when self._pool goes out of scope,
+        # we also need to join() below
+        self._pool.terminate()
+
+        # Wait for the thread pool to terminate;
+        # this is needed in order to make sure all the processes are dead when the SDB goes out of scope.
+        self._pool.join()
+
     def __contains__(self, name):
         return name in self._domains
 

--- a/moztelemetry/spark.py
+++ b/moztelemetry/spark.py
@@ -42,6 +42,15 @@ except:
 
 _sources = None
 
+# cache SimpleDB instances; they can be reused pretty easily as they do not keep much state
+_simpledb_instances = {}
+def _get_simpledb(prefix, months_retention=12, read_only=True):
+    key = (prefix, months_retention, read_only)
+    if key in _simpledb_instances:
+        return _simpledb_instances[key]
+    _simpledb_instances[key] = SDB(prefix, months_retention, read_only)
+    return _simpledb_instances[key]
+
 def get_clients_history(sc, **kwargs):
     """ Returns RDD[client_id, ping]. This API is experimental and might change entirely at any point!
     """
@@ -371,7 +380,7 @@ def _get_filenames_v2(**kwargs):
             v = None
         query[tk] = v
 
-    sdb = SDB("telemetry_v2")
+    sdb = _get_simpledb("telemetry_v2")
     return sdb.query(**query)
 
 
@@ -393,7 +402,7 @@ def _get_filenames_v4(**kwargs):
             v = None
         query[tk] = v
 
-    sdb = SDB("telemetry_v4")
+    sdb = _get_simpledb("telemetry_v4")
     return sdb.query(**query)
 
 


### PR DESCRIPTION
Calling `get_pings` in a loop will eventually (around 100 for the default hadoop setup) make us run out of threads.

This is because the threadpool for SDB shuts down asynchronously, so the number of threadpools keeps growing.

To solve this, we can make thread pool shutdown synchronous (to make the class behave correctly), and also cache the SDB instances (to make things fast again). We can cache these instances because they don't have any real mutable state.

Here's a notebook that demonstrates a loop that uses only one thread pool at a time: https://gist.github.com/Uberi/9e2315e152b35595e917