### PR TITLE
Standards crc32

### DIFF
--- a/test/test_standards.py
+++ b/test/test_standards.py
@@ -11,6 +11,8 @@ class TestStandards(unittest.TestCase):
 
         ping = {'clientId': '6fd3eb50-8bec-4b9c-8778-59406171312a'}
         self.assertRaises(ValueError, standards.in_sample, ping, 3)
+        for divisor in (10, 100, 1000):
+            self.failIf(standards.in_sample(ping, divisor))
 
         ping = {'clientId': '42fe5ab0-9b19-4d75-a9f1-0d57aada05d6'}
         for divisor in (10, 100, 1000):

--- a/test/test_standards.py
+++ b/test/test_standards.py
@@ -1,0 +1,20 @@
+import unittest
+
+from moztelemetry import standards
+
+class TestStandards(unittest.TestCase):
+
+    def test_in_sample(self):
+        ping = {'clientId': ''}
+        for divisor in (10, 100, 1000):
+            self.failIf(standards.in_sample(ping, divisor))
+
+        ping = {'clientId': '6fd3eb50-8bec-4b9c-8778-59406171312a'}
+        self.assertRaises(ValueError, standards.in_sample, ping, 3)
+
+        ping = {'clientId': '42fe5ab0-9b19-4d75-a9f1-0d57aada05d6'}
+        for divisor in (10, 100, 1000):
+            self.failUnless(standards.in_sample(ping, divisor))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
standards.in_sample(ping, divisor) tests whether a ping's clientId puts it in the crc32-based 1% sample, fixing a bug noticed by @mreid-moz (Python's crc32 routine is signed but our Lua library is apparently unsigned). I added 0.1% and 10% as subset/superset of 1%; LMK if you want a different approach. 0.1% is in use.