### PR TITLE
Bug 1302476 - Make Dataset._scan return early

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -121,7 +121,7 @@ class Dataset:
                            prefix=self.prefix, clauses=clauses)
 
     def _scan(self, dimensions, prefixes, clauses, executor):
-        if not dimensions:
+        if not dimensions or not clauses:
             return prefixes
         else:
             dimension = dimensions[0]
@@ -131,6 +131,7 @@ class Dataset:
             matched = chain(*matched)
             if clause:
                 matched = [x for x in matched if clause(x.strip('/').split('/')[-1])]
+                del clauses[dimension]
 
             return self._scan(dimensions[1:], matched, clauses, executor)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='python_moztelemetry',
-    version='0.4.0',
+    version='0.4.1',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Spark bindings for Mozilla Telemetry',

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -73,8 +73,8 @@ def test_scan_no_clause():
 
     dataset = Dataset(bucket_name, ['dim1', 'dim2'], store=store)
     with futures.ProcessPoolExecutor(1) as executor:
-        folders = dataset._scan(['dim1', 'subdir'], [''], {}, executor)
-    assert list(folders) == ['dir1/dir2/']
+        folders = dataset._scan(['dim1', 'subdir'], ['prefix'], {}, executor)
+    assert list(folders) == ['prefix']
 
 
 def test_scan_with_clause():
@@ -87,7 +87,7 @@ def test_scan_with_clause():
                       clauses={'dim1': lambda x: x == 'dir1'}, store=store)
     with futures.ProcessPoolExecutor(1) as executor:
         folders = dataset._scan(['dim1', 'dim2'], [''], dataset.clauses, executor)
-    assert list(folders) == ['dir1/subdir1/']
+    assert list(folders) == ['dir1/']
 
 
 def test_scan_with_prefix():
@@ -96,10 +96,10 @@ def test_scan_with_prefix():
     store.store['prefix1/dir1/subdir1/key1'] = 'value1'
     store.store['prefix2/dir2/another-dir/key2'] = 'value2'
     dataset = Dataset(bucket_name, ['dim1', 'dim2'],
-                      clauses={'dim2': lambda x: x == 'subdir1'}, store=store)
+                      clauses={'dim1': lambda x: x == 'dir1'}, store=store)
     with futures.ProcessPoolExecutor(1) as executor:
-        folders = dataset._scan(['dim1', 'dim2',], ['prefix1/',], {}, executor)
-    assert list(folders) == ['prefix1/dir1/subdir1/']
+        folders = dataset._scan(['dim1', 'dim2',], ['prefix1/',], dataset.clauses, executor)
+    assert list(folders) == ['prefix1/dir1/']
 
 
 def test_summaries():


### PR DESCRIPTION
If there are no conditions left to check, _scan should return the list
of prefixes retrieved up to the point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_moztelemetry/80)
<!-- Reviewable:end -->
