### PR TITLE
Bug 1304693 - Better handle datasets with many small files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='python_moztelemetry',
-    version='0.4.1',
+    version='0.4.2',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Spark bindings for Mozilla Telemetry',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,10 @@ def dummy_bucket(my_mock_s3):
 def spark_context(request):
     logger = logging.getLogger("py4j")
     logger.setLevel(logging.ERROR)
-    sc = pyspark.SparkContext(master="local[1]")
+    sc = pyspark.SparkContext(master="local[8]")
 
     finalizer = lambda : sc.stop()
     request.addfinalizer(finalizer)
 
     return sc
+


### PR DESCRIPTION
For most of the datasets grouping the source files by cumulative size
works well. For datasets with many small files, there may be cases where
the size threshold is never/hardly reached and all the files end up being in
a number of groups < defaultParallelism. Let's ignore the grouping in
those case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_moztelemetry/81)
<!-- Reviewable:end -->
