### PR TITLE
Fix Dataset.where with multiple filters

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -117,8 +117,8 @@ class Dataset:
                 clauses[dimension] = lambda x: x == condition
             else:
                 clauses[dimension] = condition
-            return Dataset(self.bucket, self.schema, store=self.store,
-                           prefix=self.prefix, clauses=clauses)
+        return Dataset(self.bucket, self.schema, store=self.store,
+                       prefix=self.prefix, clauses=clauses)
 
     def _scan(self, dimensions, prefixes, clauses, executor):
         if not dimensions or not clauses:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='python_moztelemetry',
-    version='0.4.2',
+    version='0.4.3',
     author='Roberto Agostino Vitillo',
     author_email='rvitillo@mozilla.com',
     description='Spark bindings for Mozilla Telemetry',


### PR DESCRIPTION
The filtered dataset shouldn't be returned on the first iteration but after the
for loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_moztelemetry/83)
<!-- Reviewable:end -->
