### PR TITLE
Bug 1302264 - Use metadata_prefix in the Dataset API

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -207,6 +207,6 @@ class Dataset:
         except KeyError:
             raise Exception('Unknown source {}'.format(source_name))
 
-        schema = store.get_key('{}/schema.json'.format(source['prefix'])).read()
+        schema = store.get_key('{}/schema.json'.format(source['metadata_prefix'])).read()
         dimensions = [f['field_name'] for f in json.loads(schema)['dimensions']]
         return Dataset(source['bucket'], dimensions, prefix=source['prefix'])


### PR DESCRIPTION
Similar to https://github.com/mozilla/python_moztelemetry/blob/master/moztelemetry/spark.py#L277

This value of `metadata_prefix` is usually (but not always) the same as `prefix`, which is why it has worked so far. The case where it's not is when you have two datasets with the same metadata prefix, as occasioned by forthcoming dataset migrations. 

We should produce better documentation and tooling around `sources.json` in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_moztelemetry/86)
<!-- Reviewable:end -->
