### PR TITLE
Add Zeppelin plotting helper

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -32,8 +32,5 @@ Experimental APIs
 
 .. autofunction:: moztelemetry.zeppelin.show
 
-HBaseMainSummaryView API
-------------------------
-
 .. automodule:: moztelemetry.hbase
     :members:

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -30,6 +30,8 @@ Users can then use the `RDD api <http://spark.apache.org/docs/latest/programming
 Experimental APIs
 -----------------
 
+.. autofunction:: moztelemetry.zeppelin.show
+
 HBaseMainSummaryView API
 ------------------------
 

--- a/moztelemetry/zeppelin.py
+++ b/moztelemetry/zeppelin.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, you can obtain one at http://mozilla.org/MPL/2.0/.
+
+from StringIO import StringIO
+
+
+def show(fig, width=600):
+    """ Renders a Matplotlib figure in Zeppelin.
+
+    :param fig: a Matplotlib figure
+    :param width: the width in pixel of the rendered figure, defaults to 600
+
+    Usage example::
+
+        import matplotlib.pyplot as plt
+        from moztelemetry.zeppelin import show
+
+        fig = plt.figure()
+        plt.plot([1, 2, 3])
+        show(fig)
+    """
+    img = StringIO()
+    fig.savefig(img, format='svg')
+    img.seek(0)
+    print("%html <div style='width:{}px'>{}</div>".format(width, img.buf))


### PR DESCRIPTION
Zeppelin doesn't currently support Matplotlib out of the box so this is the only way to display a plot.