### PR TITLE
Bug 1346308 - Support dataset prefixes with slashes

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -148,10 +148,6 @@ class Dataset:
         clauses = copy(self.clauses)
         schema = self.schema
 
-        if self.prefix:
-            schema = ['prefix'] + schema
-            clauses['prefix'] = lambda x: x == self.prefix
-
         with futures.ProcessPoolExecutor(MAX_CONCURRENCY) as executor:
             scanned = self._scan(schema, [self.prefix], clauses, executor)
         keys = sc.parallelize(scanned).flatMap(self.store.list_keys)


### PR DESCRIPTION
So this seems almost too easy, but the unit tests (including a new one which would stress test whether this case is working correctly) are still passing. From what I can tell, when a prefix is specified we have a filter to make sure the data we fetch from S3 matches the prefix. This doesn't work well when our prefix has slashes in it (because it depends on being able to work against the last part of the path). However, I don't see why this is even necessary because we explicitly only get data matching the prefix from S3 (https://github.com/mozilla/python_moztelemetry/blob/06d26e6/moztelemetry/dataset.py#L128)

@mreid-moz @maurodoglio Could you tell me if I'm crazy?