### PR TITLE
Fix hbase test fixtures when tests interrupted

### DIFF
--- a/tests/test_hbase.py
+++ b/tests/test_hbase.py
@@ -23,7 +23,8 @@ def view():
     column = "{}:payload".format(column_family)
 
     if table_name in conn.tables():
-        conn.disable_table(table_name)
+        if conn.is_table_enabled(table_name):
+            conn.disable_table(table_name)
         conn.delete_table(table_name)
 
     conn.create_table(table_name, {column_family: dict()})


### PR DESCRIPTION
If you interrupt the hbase unit tests when they're running, that can leave
a table in a disabled-but-not-deleted state which the current fixture
can't handle correctly. Let's account for this case.