### PR TITLE
Bug 1353032 - Depend on happybase 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
     install_requires=['boto', 'boto3', 'ujson', 'requests', 'protobuf==3.1.0',
                       'expiringdict', 'functools32', 'futures', 'py4j',
                       'pandas>=0.14.1', 'numpy>=1.8.2', 'findspark',
-                      'happybase>=1.0.0', 'PyYAML', 'python-snappy'],
-    dependency_links=['https://github.com/wbolster/happybase/archive/33b7700375ba59f1810c30c8cd531577b0718498.zip#egg=happybase-1.0.1'],
+                      'happybase==1.1.0', 'PyYAML', 'python-snappy'],
     setup_requires=['pytest-runner', 'setuptools_scm'],
     # put pytest last to workaround this bug
     # https://bitbucket.org/pypa/setuptools/issues/196/tests_require-pytest-pytest-cov-breaks


### PR DESCRIPTION
Also remove the deprecated use of dependency_links in the setup file
(which didn't work without a special command-line option).