### PR TITLE
Bug 1346308 - Fix using where() on a dataset when prefix specified

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -200,6 +200,13 @@ class Dataset:
         clauses = copy(self.clauses)
         schema = self.schema
 
+        if self.prefix:
+            schema = ['prefix'] + schema
+            # Add a clause for the prefix that always returns True, in case
+            # the output is not filtered at all (so that we do a scan/filter
+            # on the prefix directory)
+            clauses['prefix'] = lambda x: True
+
         with futures.ProcessPoolExecutor(MAX_CONCURRENCY) as executor:
             scanned = self._scan(schema, [self.prefix], clauses, executor)
         keys = sc.parallelize(scanned).flatMap(self.store.list_keys)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -372,3 +372,8 @@ def test_prefix_slash(spark_context):
     for item in summaries:
         assert item['key'] in store.store
         assert item['size'] == len(store.store[item['key']])
+
+    # be sure "where" still works
+    summaries_filtered = dataset.where(dim1='dir1').summaries(spark_context)
+    assert len(summaries_filtered) == 1
+    assert summaries_filtered[0]['key'] == 'a/b/dir1/subdir1/key1'


### PR DESCRIPTION
We need to pass in a dimension corresponding to the prefix so that we actually
scan in the appropriate folder, even if we don't actually need a clause that
filters *for* the prefix (since that is taken care of by our interaction with
the S3 API).