### PR TITLE
Minor fixes to the test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN conda update -q conda
 RUN conda info -a # Useful for debugging any issues with conda
 
 # install spark/hbase
-ADD https://d3kbcqa49mib13.cloudfront.net/spark-$SPARK_VERSION-bin-hadoop2.6.tgz /
-ADD https://archive.apache.org/dist/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz /
+RUN wget -nv https://d3kbcqa49mib13.cloudfront.net/spark-$SPARK_VERSION-bin-hadoop2.6.tgz
+RUN wget -nv https://archive.apache.org/dist/hbase/$HBASE_VERSION/hbase-$HBASE_VERSION-bin.tar.gz
 RUN tar -zxf spark-$SPARK_VERSION-bin-hadoop2.6.tgz
 RUN tar -zxf hbase-$HBASE_VERSION-bin.tar.gz
 ENV SPARK_HOME="/spark-${SPARK_VERSION}-bin-hadoop2.6"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,21 @@ RUN tar -zxf spark-$SPARK_VERSION-bin-hadoop2.6.tgz
 RUN tar -zxf hbase-$HBASE_VERSION-bin.tar.gz
 ENV SPARK_HOME="/spark-${SPARK_VERSION}-bin-hadoop2.6"
 
-COPY . /python_moztelemetry
-
 # build + activate conda environment
+COPY ./environment.yml /python_moztelemetry/
 RUN conda env create -f /python_moztelemetry/environment.yml
-RUN bash -c 'source activate test-environment'
 
-# install moztelemetry specific deps into conda env
-RUN pip install /python_moztelemetry/ --process-dependency-links
+# this is roughly equivalent to activating the conda environment
+ENV PATH="/miniconda/envs/test-environment/bin:${PATH}"
+
+WORKDIR /python_moztelemetry
+
 # we need to explicitly install pytest and dependencies so spark
 # can pick them up
 RUN pip install 'pytest>=3' coverage coveralls
 
-WORKDIR /python_moztelemetry
+# This will invalidate the cache if something changes in python_moztelemetry.
+COPY . /python_moztelemetry
+
+# install moztelemetry specific deps into conda env
+RUN pip install /python_moztelemetry/ --process-dependency-links

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,7 +17,11 @@ fi
 /hbase-$HBASE_VERSION/bin/hbase-daemon.sh start thrift
 
 # Run tests
-coverage run --source=moztelemetry setup.py test --addopts "${ARGS}"
+if [ $# -gt 1 ]; then
+    coverage run --source=moztelemetry setup.py test --addopts "${ARGS}"
+else
+    coverage run --source=moztelemetry setup.py test
+fi
 
 # Report coveralls output if using travis
 if [ $TRAVIS_BRANCH ]; then


### PR DESCRIPTION
This patch fixes a few problems with the docker test setup:
 - Conda virtual environment activation
 - runtest.sh execution with no arguments
 - Huge speedup on subsequent builds of the docker container.