### PR TITLE
Bug 1363934 - Update moztelemetry's ages-old histogram_tools, fixing tests.

### DIFF
--- a/moztelemetry/histogram.py
+++ b/moztelemetry/histogram.py
@@ -151,7 +151,9 @@ class Histogram:
             pd_index = ranges
 
         if isinstance(instance, list) or isinstance(instance, np.ndarray) or isinstance(instance, pd.Series):
-            if len(instance) == self.definition.n_buckets():
+            if self.kind == 'categorical':
+                values = instance[:len(labels) + 1]
+            elif len(instance) == self.definition.n_buckets():
                 values = instance
             else:
                 values = instance[:-5]

--- a/moztelemetry/histogram_tools.py
+++ b/moztelemetry/histogram_tools.py
@@ -9,10 +9,15 @@ import math
 import os
 import re
 import sys
+import shared_telemetry_utils as utils
+
+from shared_telemetry_utils import ParserError
+from collections import OrderedDict
 
 # Constants.
 MAX_LABEL_LENGTH = 20
 MAX_LABEL_COUNT = 100
+MIN_CATEGORICAL_BUCKET_COUNT = 50
 
 # histogram_tools.py is used by scripts from a mozilla-central build tree
 # and also by outside consumers, such as the telemetry server.  We need
@@ -30,17 +35,6 @@ except ImportError:
     # ensured it's in our sys.path.
     pass
 
-from collections import OrderedDict
-
-def table_dispatch(kind, table, body):
-    """Call body with table[kind] if it exists.  Raise an error otherwise."""
-    if kind in table:
-        return body(table[kind])
-    else:
-        raise BaseException, "don't know how to handle a histogram of kind %s" % kind
-
-class DefinitionException(BaseException):
-    pass
 
 def linear_buckets(dmin, dmax, n_buckets):
     ret_array = [0] * n_buckets
@@ -51,9 +45,10 @@ def linear_buckets(dmin, dmax, n_buckets):
         ret_array[i] = int(linear_range + 0.5)
     return ret_array
 
+
 def exponential_buckets(dmin, dmax, n_buckets):
-    log_max = math.log(dmax);
-    bucket_index = 2;
+    log_max = math.log(dmax)
+    bucket_index = 2
     ret_array = [0] * n_buckets
     current = dmin
     ret_array[1] = current
@@ -71,21 +66,24 @@ def exponential_buckets(dmin, dmax, n_buckets):
 
 always_allowed_keys = ['kind', 'description', 'cpp_guard', 'expires_in_version',
                        'alert_emails', 'keyed', 'releaseChannelCollection',
-                       'bug_numbers']
+                       'bug_numbers', 'record_in_processes']
 
-whitelists = None;
+whitelists = None
 try:
-    whitelist_path = os.path.join(os.path.abspath(os.path.realpath(os.path.dirname(__file__))), 'histogram-whitelists.json')
+    whitelist_path = os.path.join(os.path.abspath(os.path.realpath(os.path.dirname(__file__))),
+                                  'histogram-whitelists.json')
     with open(whitelist_path, 'r') as f:
         try:
             whitelists = json.load(f)
             for name, whitelist in whitelists.iteritems():
-              whitelists[name] = set(whitelist)
+                whitelists[name] = set(whitelist)
         except ValueError, e:
-            raise BaseException, 'error parsing whitelist (%s)' % whitelist_path
+            raise ParserError('Error parsing whitelist: %s' % whitelist_path)
 except IOError:
     whitelists = None
-    print 'Unable to parse whitelist (%s). Assuming all histograms are acceptable.' % whitelist_path
+    print('Unable to parse whitelist: %s.\nAssuming all histograms are acceptable.' %
+          whitelist_path)
+
 
 class Histogram:
     """A class for representing a histogram definition."""
@@ -105,6 +103,8 @@ The key 'cpp_guard' is optional; if present, it denotes a preprocessor
 symbol that should guard C/C++ definitions associated with the histogram."""
         self._strict_type_checks = strict_type_checks
         self._is_use_counter = name.startswith("USE_COUNTER2_")
+        if self._is_use_counter:
+            definition.setdefault('record_in_processes', ['main', 'content'])
         self.verify_attributes(name, definition)
         self._name = name
         self._description = definition['description']
@@ -113,24 +113,10 @@ symbol that should guard C/C++ definitions associated with the histogram."""
         self._keyed = definition.get('keyed', False)
         self._expiration = definition.get('expires_in_version')
         self._labels = definition.get('labels', [])
+
         self.compute_bucket_parameters(definition)
-        table = {
-            'boolean': 'BOOLEAN',
-            'flag': 'FLAG',
-            'count': 'COUNT',
-            'enumerated': 'LINEAR',
-            'categorical': 'CATEGORICAL',
-            'linear': 'LINEAR',
-            'exponential': 'EXPONENTIAL',
-        }
-        table_dispatch(self.kind(), table,
-                       lambda k: self._set_nsITelemetry_kind(k))
-        datasets = { 'opt-in': 'DATASET_RELEASE_CHANNEL_OPTIN',
-                     'opt-out': 'DATASET_RELEASE_CHANNEL_OPTOUT' }
-        value = definition.get('releaseChannelCollection', 'opt-in')
-        if not value in datasets:
-            raise DefinitionException, "unknown release channel collection policy for " + name
-        self._dataset = "nsITelemetry::" + datasets[value]
+        self.set_nsITelemetry_kind()
+        self.set_dataset(definition)
 
     def name(self):
         """Return the name of the histogram."""
@@ -154,9 +140,6 @@ or 'exponential'."""
         """Return the nsITelemetry constant corresponding to the kind of
 the histogram."""
         return self._nsITelemetry_kind
-
-    def _set_nsITelemetry_kind(self, kind):
-        self._nsITelemetry_kind = "nsITelemetry::HISTOGRAM_%s" % kind
 
     def low(self):
         """Return the lower bound of the histogram."""
@@ -187,9 +170,17 @@ associated with the histogram.  Returns None if no guarding is necessary."""
         """Returns a list of labels for a categorical histogram, [] for others."""
         return self._labels
 
+    def record_in_processes(self):
+        """Returns a list of processes this histogram is permitted to record in."""
+        return self.definition['record_in_processes']
+
+    def record_in_processes_enum(self):
+        """Get the non-empty list of flags representing the processes to record data in"""
+        return [utils.process_name_to_enum(p) for p in self.record_in_processes]
+
     def ranges(self):
         """Return an array of lower bounds for each bucket in the histogram."""
-        table = {
+        bucket_fns = {
             'boolean': linear_buckets,
             'flag': linear_buckets,
             'count': linear_buckets,
@@ -198,11 +189,15 @@ associated with the histogram.  Returns None if no guarding is necessary."""
             'linear': linear_buckets,
             'exponential': exponential_buckets,
         }
-        return table_dispatch(self.kind(), table,
-                              lambda p: p(self.low(), self.high(), self.n_buckets()))
+
+        if self._kind not in bucket_fns:
+            raise ParserError('Unknown kind "%s" for histogram "%s".' % (self._kind, self._name))
+
+        fn = bucket_fns[self._kind]
+        return fn(self.low(), self.high(), self.n_buckets())
 
     def compute_bucket_parameters(self, definition):
-        table = {
+        bucket_fns = {
             'boolean': Histogram.boolean_flag_bucket_parameters,
             'flag': Histogram.boolean_flag_bucket_parameters,
             'count': Histogram.boolean_flag_bucket_parameters,
@@ -211,8 +206,12 @@ associated with the histogram.  Returns None if no guarding is necessary."""
             'linear': Histogram.linear_bucket_parameters,
             'exponential': Histogram.exponential_bucket_parameters,
         }
-        table_dispatch(self.kind(), table,
-                       lambda p: self.set_bucket_parameters(*p(definition)))
+
+        if self._kind not in bucket_fns:
+            raise ParserError('Unknown kind "%s" for histogram "%s".' % (self._kind, self._name))
+
+        fn = bucket_fns[self._kind]
+        self.set_bucket_parameters(*fn(definition))
 
     def verify_attributes(self, name, definition):
         global always_allowed_keys
@@ -223,7 +222,7 @@ associated with the histogram.  Returns None if no guarding is necessary."""
             'flag': always_allowed_keys,
             'count': always_allowed_keys,
             'enumerated': always_allowed_keys + ['n_values'],
-            'categorical': always_allowed_keys + ['labels'],
+            'categorical': always_allowed_keys + ['labels', 'n_values'],
             'linear': general_keys,
             'exponential': general_keys,
         }
@@ -232,22 +231,28 @@ associated with the histogram.  Returns None if no guarding is necessary."""
         if not self._strict_type_checks:
             table['exponential'].append('extended_statistics_ok')
 
-        table_dispatch(definition['kind'], table,
-                       lambda allowed_keys: Histogram.check_keys(name, definition, allowed_keys))
+        kind = definition['kind']
+        if kind not in table:
+            raise ParserError('Unknown kind "%s" for histogram "%s".' % (kind, name))
+        allowed_keys = table[kind]
 
         self.check_name(name)
+        self.check_keys(name, definition, allowed_keys)
         self.check_field_types(name, definition)
+        self.check_whitelisted_kind(name, definition)
         self.check_whitelistable_fields(name, definition)
         self.check_expiration(name, definition)
         self.check_label_values(name, definition)
+        self.check_record_in_processes(name, definition)
 
     def check_name(self, name):
         if '#' in name:
-            raise ValueError, '"#" not permitted for %s' % (name)
+            raise ParserError('Error for histogram name "%s": "#" is not allowed.' % (name))
 
         # Avoid C++ identifier conflicts between histogram enums and label enum names.
         if name.startswith("LABELS_"):
-            raise ValueError, "Histogram name '%s' can not start with LABELS_" % (name)
+            raise ParserError('Error for histogram name "%s":  can not start with "LABELS_".' %
+                              (name))
 
         # To make it easier to generate C++ identifiers from this etc., we restrict
         # the histogram names to a strict pattern.
@@ -255,20 +260,27 @@ associated with the histogram.  Returns None if no guarding is necessary."""
         if self._strict_type_checks:
             pattern = '^[a-z][a-z0-9_]+[a-z0-9]$'
             if not re.match(pattern, name, re.IGNORECASE):
-                raise ValueError, "Histogram name '%s' doesn't confirm to '%s'" % (name, pattern)
+                raise ParserError('Error for histogram name "%s": name does not conform to "%s"' %
+                                  (name, pattern))
 
     def check_expiration(self, name, definition):
-        expiration = definition.get('expires_in_version')
+        field = 'expires_in_version'
+        expiration = definition.get(field)
 
         if not expiration:
             return
+
+        # We forbid new probes from using "expires_in_version" : "default" field/value pair.
+        # Old ones that use this are added to the whitelist.
+        if expiration == "default" and name not in whitelists['expiry_default']:
+            raise ParserError('New histogram "%s" cannot have "default" %s value.' % (name, field))
 
         if re.match(r'^[1-9][0-9]*$', expiration):
             expiration = expiration + ".0a1"
         elif re.match(r'^[1-9][0-9]*\.0$', expiration):
             expiration = expiration + "a1"
 
-        definition['expires_in_version'] = expiration
+        definition[field] = expiration
 
     def check_label_values(self, name, definition):
         labels = definition.get('labels')
@@ -277,20 +289,58 @@ associated with the histogram.  Returns None if no guarding is necessary."""
 
         invalid = filter(lambda l: len(l) > MAX_LABEL_LENGTH, labels)
         if len(invalid) > 0:
-            raise ValueError, 'Label values for %s exceed length limit of %d: %s' % \
-                              (name, MAX_LABEL_LENGTH, ', '.join(invalid))
+            raise ParserError('Label values for "%s" exceed length limit of %d: %s' %
+                              (name, MAX_LABEL_LENGTH, ', '.join(invalid)))
 
         if len(labels) > MAX_LABEL_COUNT:
-            raise ValueError, 'Label count for %s exceeds limit of %d' % \
-                              (name, MAX_LABEL_COUNT)
+            raise ParserError('Label count for "%s" exceeds limit of %d' %
+                              (name, MAX_LABEL_COUNT))
 
         # To make it easier to generate C++ identifiers from this etc., we restrict
         # the label values to a strict pattern.
         pattern = '^[a-z][a-z0-9_]+[a-z0-9]$'
         invalid = filter(lambda l: not re.match(pattern, l, re.IGNORECASE), labels)
         if len(invalid) > 0:
-            raise ValueError, 'Label values for %s are not matching pattern "%s": %s' % \
-                              (name, pattern, ', '.join(invalid))
+            raise ParserError('Label values for %s are not matching pattern "%s": %s' %
+                              (name, pattern, ', '.join(invalid)))
+
+    def check_record_in_processes(self, name, definition):
+        field = 'record_in_processes'
+        rip = definition.get(field)
+
+        if not rip:
+            raise ParserError('Histogram "%s" must have a "%s" field.' % (name, field))
+
+        for process in rip:
+            if not utils.is_valid_process_name(process):
+                raise ParserError('Histogram "%s" has unknown process "%s" in %s.' %
+                                  (name, process, field))
+
+    def check_whitelisted_kind(self, name, definition):
+        # We don't need to run any of these checks on the server.
+        if not self._strict_type_checks or whitelists is None:
+            return
+
+        DOC_URL = ("https://gecko.readthedocs.io/en/latest/toolkit/"
+                   "components/telemetry/telemetry/collection/scalars.html")
+
+        # Disallow "flag" and "count" histograms on desktop, suggest to use
+        # scalars instead. Allow using these histograms on Android, as we
+        # don't support scalars there yet.
+        hist_kind = definition.get("kind")
+        android_cpp_guard =\
+            definition.get("cpp_guard") in ["ANDROID", "MOZ_WIDGET_ANDROID"]
+
+        if not android_cpp_guard and \
+           hist_kind in ["flag", "count"] and \
+           name not in whitelists["kind"]:
+            raise ParserError(('Unsupported kind "%s" for histogram "%s":\n'
+                               'New "%s" histograms are not supported on Desktop, you should'
+                               ' use scalars instead:\n'
+                               '%s\n'
+                               'Are you trying to add a histogram on Android?'
+                               ' Add "cpp_guard": "ANDROID" to your histogram definition.')
+                              % (hist_kind, name, hist_kind, DOC_URL))
 
     # Check for the presence of fields that old histograms are whitelisted for.
     def check_whitelistable_fields(self, name, definition):
@@ -306,10 +356,11 @@ associated with the histogram.  Returns None if no guarding is necessary."""
 
         for field in ['alert_emails', 'bug_numbers']:
             if field not in definition and name not in whitelists[field]:
-                raise KeyError, 'New histogram "%s" must have a %s field.' % (name, field)
+                raise ParserError('New histogram "%s" must have a "%s" field.' % (name, field))
             if field in definition and name in whitelists[field]:
-                msg = 'Should remove histogram "%s" from the whitelist for "%s" in histogram-whitelists.json'
-                raise KeyError, msg % (name, field)
+                msg = 'Histogram "%s" should be removed from the whitelist for "%s" in ' \
+                      'histogram-whitelists.json.'
+                raise ParserError(msg % (name, field))
 
     def check_field_types(self, name, definition):
         # Define expected types for the histogram properties.
@@ -331,6 +382,7 @@ associated with the histogram.  Returns None if no guarding is necessary."""
             "bug_numbers": int,
             "alert_emails": basestring,
             "labels": basestring,
+            "record_in_processes": basestring,
         }
 
         # For the server-side, where _strict_type_checks==False, we want to
@@ -355,24 +407,23 @@ associated with the histogram.  Returns None if no guarding is necessary."""
             return t.__name__
 
         for key, key_type in type_checked_fields.iteritems():
-            if not key in definition:
+            if key not in definition:
                 continue
             if not isinstance(definition[key], key_type):
-                raise ValueError, ('value for key "{0}" in Histogram "{1}" '
-                        'should be {2}').format(key, name, nice_type_name(key_type))
+                raise ParserError('Value for key "{0}" in histogram "{1}" should be {2}.'
+                                  .format(key, name, nice_type_name(key_type)))
 
         for key, key_type in type_checked_list_fields.iteritems():
-            if not key in definition:
+            if key not in definition:
                 continue
             if not all(isinstance(x, key_type) for x in definition[key]):
-                raise ValueError, ('all values for list "{0}" in Histogram "{1}" '
-                        'should be {2}').format(key, name, nice_type_name(key_type))
+                raise ParserError('All values for list "{0}" in histogram "{1}" should be of type'
+                                  ' {2}.'.format(key, name, nice_type_name(key_type)))
 
-    @staticmethod
-    def check_keys(name, definition, allowed_keys):
+    def check_keys(self, name, definition, allowed_keys):
         for key in definition.iterkeys():
             if key not in allowed_keys:
-                raise KeyError, '%s not permitted for %s' % (key, name)
+                raise ParserError('Key "%s" is not allowed for histogram "%s".' % (key, name))
 
     def set_bucket_parameters(self, low, high, n_buckets):
         self._low = low
@@ -380,9 +431,14 @@ associated with the histogram.  Returns None if no guarding is necessary."""
         self._n_buckets = n_buckets
         if whitelists is not None and self._n_buckets > 100 and type(self._n_buckets) is int:
             if self._name not in whitelists['n_buckets']:
-                raise KeyError, ('New histogram "%s" is not permitted to have more than 100 buckets. '
-                                'Histograms with large numbers of buckets use disproportionately high amounts of resources. '
-                                'Contact the Telemetry team (e.g. in #telemetry) if you think an exception ought to be made.' % self._name)
+                raise ParserError(
+                    'New histogram "%s" is not permitted to have more than 100 buckets.\n'
+                    'Histograms with large numbers of buckets use disproportionately high'
+                    ' amounts of resources. Contact a Telemetry peer (e.g. in #telemetry)'
+                    ' if you think an exception ought to be made:\n'
+                    'https://wiki.mozilla.org/Modules/Toolkit#Telemetry'
+                    % self._name
+                    )
 
     @staticmethod
     def boolean_flag_bucket_parameters(definition):
@@ -401,7 +457,13 @@ associated with the histogram.  Returns None if no guarding is necessary."""
 
     @staticmethod
     def categorical_bucket_parameters(definition):
-        n_values = len(definition['labels'])
+        # Categorical histograms default to 50 buckets to make working with them easier.
+        # Otherwise when adding labels later we run into problems with the pipeline not
+        # supporting bucket changes.
+        # This can be overridden using the n_values field.
+        n_values = max(len(definition['labels']),
+                       definition.get('n_values', 0),
+                       MIN_CATEGORICAL_BUCKET_COUNT)
         return (1, n_values, n_values + 1)
 
     @staticmethod
@@ -410,6 +472,48 @@ associated with the histogram.  Returns None if no guarding is necessary."""
                 definition['high'],
                 definition['n_buckets'])
 
+    def set_nsITelemetry_kind(self):
+        # Pick a Telemetry implementation type.
+        types = {
+            'boolean': 'BOOLEAN',
+            'flag': 'FLAG',
+            'count': 'COUNT',
+            'enumerated': 'LINEAR',
+            'categorical': 'CATEGORICAL',
+            'linear': 'LINEAR',
+            'exponential': 'EXPONENTIAL',
+        }
+
+        if self._kind not in types:
+            raise ParserError('Unknown kind "%s" for histogram "%s".' % (self._kind, self._name))
+
+        self._nsITelemetry_kind = "nsITelemetry::HISTOGRAM_%s" % types[self._kind]
+
+    def set_dataset(self, definition):
+        datasets = {
+            'opt-in': 'DATASET_RELEASE_CHANNEL_OPTIN',
+            'opt-out': 'DATASET_RELEASE_CHANNEL_OPTOUT'
+        }
+
+        value = definition.get('releaseChannelCollection', 'opt-in')
+        if value not in datasets:
+            raise ParserError('Unknown value for releaseChannelCollection'
+                              ' policy for histogram "%s".' % self._name)
+
+        self._dataset = "nsITelemetry::" + datasets[value]
+
+
+# This hook function loads the histograms into an OrderedDict.
+# It will raise a ParserError if duplicate keys are found.
+def load_histograms_into_dict(ordered_pairs):
+    d = collections.OrderedDict()
+    for key, value in ordered_pairs:
+        if key in d:
+            raise ParserError("Found duplicate key in Histograms file: %s" % key)
+        d[key] = value
+    return d
+
+
 # We support generating histograms from multiple different input files, not
 # just Histograms.json.  For each file's basename, we have a specific
 # routine to parse that file, and return a dictionary mapping histogram
@@ -417,13 +521,15 @@ associated with the histogram.  Returns None if no guarding is necessary."""
 def from_Histograms_json(filename):
     with open(filename, 'r') as f:
         try:
-            histograms = json.load(f, object_pairs_hook=OrderedDict)
+            histograms = json.load(f, object_pairs_hook=load_histograms_into_dict)
         except ValueError, e:
-            raise BaseException, "error parsing histograms in %s: %s" % (filename, e.message)
+            raise ParserError("error parsing histograms in %s: %s" % (filename, e.message))
     return histograms
+
 
 def from_UseCounters_conf(filename):
     return usecounters.generate_histograms(filename)
+
 
 def from_nsDeprecatedOperationList(filename):
     operation_regex = re.compile('^DEPRECATED_OPERATION\\(([^)]+)\\)')
@@ -463,6 +569,7 @@ try:
 except ImportError:
     pass
 
+
 def from_files(filenames):
     """Return an iterator that provides a sequence of Histograms for
 the histograms defined in filenames.
@@ -477,31 +584,33 @@ the histograms defined in filenames.
         # all_histograms stable, which makes ordering in generated files
         # stable, which makes builds more deterministic.
         if not isinstance(histograms, OrderedDict):
-            raise BaseException, "histogram parser didn't provide an OrderedDict"
+            raise ParserError("Histogram parser did not provide an OrderedDict.")
 
         for (name, definition) in histograms.iteritems():
-            if all_histograms.has_key(name):
-                raise DefinitionException, "duplicate histogram name %s" % name
+            if name in all_histograms:
+                raise ParserError('Duplicate histogram name "%s".' % name)
             all_histograms[name] = definition
 
     # We require that all USE_COUNTER2_* histograms be defined in a contiguous
     # block.
     use_counter_indices = filter(lambda x: x[1].startswith("USE_COUNTER2_"),
-                                 enumerate(all_histograms.iterkeys()));
+                                 enumerate(all_histograms.iterkeys()))
     if use_counter_indices:
         lower_bound = use_counter_indices[0][0]
         upper_bound = use_counter_indices[-1][0]
         n_counters = upper_bound - lower_bound + 1
         if n_counters != len(use_counter_indices):
-            raise DefinitionException, "use counter histograms must be defined in a contiguous block"
+            raise ParserError("Use counter histograms must be defined in a contiguous block.")
 
-    # Check that histograms that were removed from Histograms.json etc. are also removed from the whitelists.
+    # Check that histograms that were removed from Histograms.json etc.
+    # are also removed from the whitelists.
     if whitelists is not None:
         all_whitelist_entries = itertools.chain.from_iterable(whitelists.itervalues())
         orphaned = set(all_whitelist_entries) - set(all_histograms.keys())
         if len(orphaned) > 0:
-            msg = 'The following entries are orphaned and should be removed from histogram-whitelists.json: %s'
-            raise BaseException, msg % (', '.join(sorted(orphaned)))
+            msg = 'The following entries are orphaned and should be removed from ' \
+                  'histogram-whitelists.json:\n%s'
+            raise ParserError(msg % (', '.join(sorted(orphaned))))
 
     for (name, definition) in all_histograms.iteritems():
         yield Histogram(name, definition, strict_type_checks=True)

--- a/moztelemetry/shared_telemetry_utils.py
+++ b/moztelemetry/shared_telemetry_utils.py
@@ -1,0 +1,132 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# This file contains utility functions shared by the scalars and the histogram generation
+# scripts.
+
+from __future__ import print_function
+
+import re
+
+# This is a list of flags that determine which process a measurement is allowed
+# to record from.
+KNOWN_PROCESS_FLAGS = {
+    'all': 'All',
+    'all_childs': 'AllChilds',
+    'main': 'Main',
+    'content': 'Content',
+    'gpu': 'Gpu',
+}
+
+PROCESS_ENUM_PREFIX = "mozilla::Telemetry::Common::RecordedProcessType::"
+
+
+# This is thrown by the different probe parsers.
+class ParserError(Exception):
+    pass
+
+
+def is_valid_process_name(name):
+    return (name in KNOWN_PROCESS_FLAGS)
+
+
+def process_name_to_enum(name):
+    return PROCESS_ENUM_PREFIX + KNOWN_PROCESS_FLAGS.get(name)
+
+
+class StringTable:
+    """Manages a string table and allows C style serialization to a file."""
+
+    def __init__(self):
+        self.current_index = 0
+        self.table = {}
+
+    def c_strlen(self, string):
+        """The length of a string including the null terminating character.
+        :param string: the input string.
+        """
+        return len(string) + 1
+
+    def stringIndex(self, string):
+        """Returns the index in the table of the provided string. Adds the string to
+        the table if it's not there.
+        :param string: the input string.
+        """
+        if string in self.table:
+            return self.table[string]
+        else:
+            result = self.current_index
+            self.table[string] = result
+            self.current_index += self.c_strlen(string)
+            return result
+
+    def stringIndexes(self, strings):
+        """ Returns a list of indexes for the provided list of strings.
+        Adds the strings to the table if they are not in it yet.
+        :param strings: list of strings to put into the table.
+        """
+        return [self.stringIndex(s) for s in strings]
+
+    def writeDefinition(self, f, name):
+        """Writes the string table to a file as a C const char array.
+
+        This writes out the string table as one single C char array for memory
+        size reasons, separating the individual strings with '\0' characters.
+        This way we can index directly into the string array and avoid the additional
+        storage costs for the pointers to them (and potential extra relocations for those).
+
+        :param f: the output stream.
+        :param name: the name of the output array.
+        """
+        entries = self.table.items()
+        entries.sort(key=lambda x: x[1])
+
+        # Avoid null-in-string warnings with GCC and potentially
+        # overlong string constants; write everything out the long way.
+        def explodeToCharArray(string):
+            def toCChar(s):
+                if s == "'":
+                    return "'\\''"
+                else:
+                    return "'%s'" % s
+            return ", ".join(map(toCChar, string))
+
+        f.write("const char %s[] = {\n" % name)
+        for (string, offset) in entries:
+            if "*/" in string:
+                raise ValueError("String in string table contains unexpected sequence '*/': %s" %
+                                 string)
+
+            e = explodeToCharArray(string)
+            if e:
+                f.write("  /* %5d - \"%s\" */ %s, '\\0',\n"
+                        % (offset, string, explodeToCharArray(string)))
+            else:
+                f.write("  /* %5d - \"%s\" */ '\\0',\n" % (offset, string))
+        f.write("};\n\n")
+
+
+def static_assert(output, expression, message):
+    """Writes a C++ compile-time assertion expression to a file.
+    :param output: the output stream.
+    :param expression: the expression to check.
+    :param message: the string literal that will appear if the expression evaluates to
+        false.
+    """
+    print("static_assert(%s, \"%s\");" % (expression, message), file=output)
+
+
+def add_expiration_postfix(expiration):
+    """ Formats the expiration version and adds a version postfix if needed.
+
+    :param expiration: the expiration version string.
+    :return: the modified expiration string.
+    """
+    if re.match(r'^[1-9][0-9]*$', expiration):
+        return expiration + ".0a1"
+
+    if re.match(r'^[1-9][0-9]*\.0$', expiration):
+        return expiration + "a1"
+
+    return expiration

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,8 @@ exclude=moztelemetry/histogram_tools.py
 #   which are very useful for alignment
 # * F501: "line too long"
 ignore=E221,E226,E241,E251,E501
+
+[coverage:run]
+omit=
+    moztelemetry/shared_telemetry_utils.py
+    moztelemetry/histogram_tools.py

--- a/tests/test_histogram.py
+++ b/tests/test_histogram.py
@@ -27,7 +27,7 @@ def test_histogram_without_revision():
     # Histogram without revision
     Histogram("STARTUP_CRASH_DETECTED",
               [1, 0, 0, 0, -1, -1, 0, 0],
-              "http://hg.mozilla.org/mozilla-central/rev/da2f28836843")
+              "https://hg.mozilla.org/mozilla-central/rev/838652a84b76")
 
 
 @pytest.mark.slow
@@ -38,7 +38,7 @@ def test_histogram_with_revision():
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0, 0, 0, 0, 0, 0, 1, 0.693147182464599, 0.480453014373779, -1,
                -1],
-              "http://hg.mozilla.org/mozilla-central/rev/37ddc5e2eb72")
+              "https://hg.mozilla.org/mozilla-central/rev/838652a84b76")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
It's been a while since moztelemetry's copy of histogram_tools was updated so
there are two things that need to be addressed.

1) We need to handle that Categorical histograms have a default of 50 n_buckets
So truncate values as moztelemetry.Histograms are constructed

2) record_in_processes is required in histogram definitions
So use more recent versions of histogram definitions that comply

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/python_moztelemetry/151)
<!-- Reviewable:end -->
