### PR TITLE
Update instructions for publishing to PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,12 @@ pip install python_moztelemetry
 [distutils]
 index-servers=pypi
 [pypi]
-repository = https://pypi.python.org/pypi
-[pypi]
 username:example_user
 password:example_pass
 ```
 - Fetch the latest code with `git pull`
 - Update PyPI with `python setup.py sdist upload`
+- If you encounter errors, make sure you are using a recent version of `setuptools`.
 
 
 ## Updating histogram_tools.py


### PR DESCRIPTION
The procedure has changed slightly, see the following:
https://packaging.python.org/guides/migrating-to-pypi-org/#uploading