### PR TITLE
Bug 1380438 - Make scalar names case-insensitive

### DIFF
--- a/moztelemetry/scalar.py
+++ b/moztelemetry/scalar.py
@@ -23,6 +23,10 @@ REVISIONS = {'nightly': 'https://hg.mozilla.org/mozilla-central/rev/tip',
              'release': 'https://hg.mozilla.org/releases/mozilla-release/rev/tip'}
 
 
+class MissingScalarError(KeyError):
+    pass
+
+
 class Scalar(object):
     """A class representing a scalar"""
 
@@ -109,5 +113,8 @@ class Scalar(object):
             Scalar._definition_cache[url] = definitions
         else:
             definitions = Scalar._definition_cache[url]
+
+        if metric.lower() not in definitions:
+            raise MissingScalarError("Definition not found for {}".format(metric))
 
         return definitions.get(metric.lower(), {})

--- a/moztelemetry/scalar.py
+++ b/moztelemetry/scalar.py
@@ -90,13 +90,14 @@ class Scalar(object):
 
     @staticmethod
     def _yaml_unnest(defs):
-        """The yaml definition file is nested - this functions unnests it.
+        """The yaml definition file is nested - this functions unnests it,
+           as well as lowercasing all keys.
         # example
         >>> test = {'browser.nav': {'clicks': {'description': 'desc', 'expires': 'never'}}}
         >>> yaml_unnest(test)
         # {'browser.nav.clicks': {'description': 'desc', 'expires': 'never'}}
         """
-        return {'{}.{}'.format(outer_key, inner_key): inner_val
+        return {'{}.{}'.format(outer_key, inner_key).lower(): inner_val
                 for outer_key, outer_val in defs.iteritems()
                 for inner_key, inner_val in outer_val.iteritems()}
 
@@ -109,4 +110,4 @@ class Scalar(object):
         else:
             definitions = Scalar._definition_cache[url]
 
-        return definitions.get(metric, {})
+        return definitions.get(metric.lower(), {})

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -124,3 +124,14 @@ def test_cache(add_response):
     assert scalar_2.get_value() == value
     assert scalar_2.get_name() == name
     assert Scalar.REQUIRED_FIELDS.issubset(scalar_2.get_definition().viewkeys())
+
+
+@responses.activate
+def test_any_case(add_response):
+    name, value = 'telemetry.test.UNSIGNED_int_kind', 8
+    Scalar(name, value)
+    scalar_2 = Scalar(name, value)
+
+    assert scalar_2.get_value() == value
+    assert scalar_2.get_name() == name
+    assert Scalar.REQUIRED_FIELDS.issubset(scalar_2.get_definition().viewkeys())

--- a/tests/test_scalar.py
+++ b/tests/test_scalar.py
@@ -1,7 +1,7 @@
 import pytest
 import responses
 
-from moztelemetry.scalar import Scalar
+from moztelemetry.scalar import Scalar, MissingScalarError
 
 
 scalar_file = '/toolkit/components/telemetry/Scalars.yaml'
@@ -135,3 +135,10 @@ def test_any_case(add_response):
     assert scalar_2.get_value() == value
     assert scalar_2.get_name() == name
     assert Scalar.REQUIRED_FIELDS.issubset(scalar_2.get_definition().viewkeys())
+
+
+@responses.activate
+def test_missing_scalar_error(add_response):
+    name, value = 'telemetry.test.missing_kind', 8
+    with pytest.raises(MissingScalarError):
+        Scalar(name, value)


### PR DESCRIPTION
We are guaranteed that no two scalars in scalars.yaml will share
a case-insensitive name. Currently, the Scalar class fails to
return a scalar when given a proper scalar name that is not
cased correctly. This change matches any case.