### PR TITLE
Remove Coveralls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /python_moztelemetry
 
 # we need to explicitly install pytest and dependencies so spark
 # can pick them up
-RUN pip install 'pytest>=3' coverage coveralls
+RUN pip install 'pytest>=3' coverage
 
 # This will invalidate the cache if something changes in python_moztelemetry.
 COPY . /python_moztelemetry

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ ENV SPARK_VERSION=2.0.2
 # install gcc
 RUN apt-get update --fix-missing && \
     apt-get install -y \
-    g++ libpython-dev libsnappy-dev
+    g++ libpython-dev libsnappy-dev \
+    build-essential libssl-dev libffi-dev
 
 # setup conda environment
 # temporary workaround, pin miniconda version until it's fixed.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /python_moztelemetry
 
 # we need to explicitly install pytest and dependencies so spark
 # can pick them up
-RUN pip install 'pytest>=3' coverage
+RUN pip install 'pytest>=3'
 
 # This will invalidate the cache if something changes in python_moztelemetry.
 COPY . /python_moztelemetry

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
  
-# python_moztelemetry [![Build Status](https://travis-ci.org/mozilla/python_moztelemetry.svg?branch=master)](https://travis-ci.org/mozilla/python_moztelemetry) [![Coverage Status](https://coveralls.io/repos/github/mozilla/python_moztelemetry/badge.svg?branch=master)](https://coveralls.io/github/mozilla/python_moztelemetry?branch=master) [![Documentation Status](http://readthedocs.org/projects/python_moztelemetry/badge/?version=latest)](https://python_moztelemetry.readthedocs.io/?badge=latest) [![Updates](https://pyup.io/repos/github/mozilla/python_moztelemetry/shield.svg)](https://pyup.io/repos/github/mozilla/python_moztelemetry/)
+# python_moztelemetry [![Build Status](https://travis-ci.org/mozilla/python_moztelemetry.svg?branch=master)](https://travis-ci.org/mozilla/python_moztelemetry) [![Documentation Status](http://readthedocs.org/projects/python_moztelemetry/badge/?version=latest)](https://python_moztelemetry.readthedocs.io/?badge=latest) [![Updates](https://pyup.io/repos/github/mozilla/python_moztelemetry/shield.svg)](https://pyup.io/repos/github/mozilla/python_moztelemetry/)
 
 Spark bindings for Mozilla Telemetry
 

--- a/runtests.sh
+++ b/runtests.sh
@@ -17,8 +17,3 @@ if [ $# -gt 0 ]; then
 else
     coverage run --source=moztelemetry setup.py test
 fi
-
-# Report coveralls output if using travis
-if [ $TRAVIS_BRANCH ]; then
-  coveralls
-fi

--- a/runtests.sh
+++ b/runtests.sh
@@ -13,7 +13,7 @@ fi
 # Run tests
 if [ $# -gt 0 ]; then
     ARGS="$@"
-    coverage run --source=moztelemetry setup.py test --addopts "${ARGS}"
+    python setup.py test --addopts "${ARGS}"
 else
-    coverage run --source=moztelemetry setup.py test
+    python setup.py test
 fi


### PR DESCRIPTION
Coveralls is currently making it impossible to merge PRs, since
they are not having the coveralls status reported. Admins also
cannot override this.