### PR TITLE
Bug 1445774 - Port client sampling to python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV SPARK_VERSION=2.0.2
 RUN apt-get update --fix-missing && \
     apt-get install -y \
     g++ libpython-dev libsnappy-dev \
-    build-essential libssl-dev libffi-dev
+    build-essential libssl-dev libffi-dev git
 
 # setup conda environment
 # temporary workaround, pin miniconda version until it's fixed.


### PR DESCRIPTION
> this would be most useful if we want to sample down from a dataframe already filtered by sample_id, so we may want to detect the first non-empty modulo result

as long as we re-use the sample_id we filter by (optionally plus multiples of 100), and modulo is a multiple of 100, then that use case is covered.