### PR TITLE
 Bug 1447851 - Add content decoding for landfill

### DIFF
--- a/moztelemetry/heka/message_parser.py
+++ b/moztelemetry/heka/message_parser.py
@@ -41,28 +41,16 @@ def _parse_heka_record(record):
             # Further special case: the content field (bytes) in landfill
             # messages is an unprocessed form of the data, usually the original
             # gzipped payload from the client.
-            # (a) In this case we pass the byte string along as-is.
-            elif field.name == 'content':
-                payload = {"content": field.value_bytes[0]}
-                break
-            # (b) In this case we attempt to decompress it, and if that fails,
+            #
+            # We attempt to decompress it, and if that fails,
             # attempt to decode it as a UTF-8 string.
             elif field.name == 'content':
                 try:
                     string = zlib.decompress(field.value_bytes[0], 16+zlib.MAX_WBITS)
-                except:  # noqa
+                except Exception as e:  # noqa
+                    raise e
                     string = field.value_bytes[0].decode('utf-8')
                 payload = {"content": string}
-                break
-            # (c) In this case we attempt to decompress it, and if that fails,
-            # attempt to decode it as a UTF-8 string, and if either of those
-            # succeeds, parse it as the payload.
-            elif field.name == 'content':
-                try:
-                    string = zlib.decompress(field.value_bytes[0], 16+zlib.MAX_WBITS)
-                except:  # noqa
-                    string = field.value_bytes[0].decode('utf-8')
-                payload = _parse_json(string)
                 break
 
     if payload is None:

--- a/moztelemetry/heka/message_parser.py
+++ b/moztelemetry/heka/message_parser.py
@@ -48,7 +48,11 @@ def _parse_heka_record(record):
                 try:
                     string = zlib.decompress(field.value_bytes[0], 16+zlib.MAX_WBITS)
                 except zlib.error:
-                    string = field.value_bytes[0].decode('utf-8')
+                    try:
+                        string = field.value_bytes[0].decode('utf-8')
+                    except UnicodeDecodeError:
+                        # There is no associated payload
+                        break
                 payload = {"content": string}
                 break
 

--- a/moztelemetry/heka/message_parser.py
+++ b/moztelemetry/heka/message_parser.py
@@ -47,8 +47,7 @@ def _parse_heka_record(record):
             elif field.name == 'content':
                 try:
                     string = zlib.decompress(field.value_bytes[0], 16+zlib.MAX_WBITS)
-                except Exception as e:  # noqa
-                    raise e
+                except zlib.error:
                     string = field.value_bytes[0].decode('utf-8')
                 payload = {"content": string}
                 break

--- a/tests/heka/test_message_parser.py
+++ b/tests/heka/test_message_parser.py
@@ -218,23 +218,32 @@ def test_landfill_utf8_content():
     assert json.dumps(parsed) == json.dumps(expected)
 
 
-def test_landfill_invalid_content_raises_exception():
+def test_landfill_invalid_content_is_empty():
+    message = Message(
+        timestamp=1,
+        type="t",
+        hostname="h",
+        payload=None,
+        fields=[
+            Field(
+                name="content",
+                value_string=None,
+                # impossible unicode byte sequence
+                # http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
+                value_bytes=['\xfe\xfe\xff\xff'],
+                value_type=1
+            )
+        ]
+    )
 
-    with pytest.raises(UnicodeDecodeError):
-        message = Message(
-            timestamp=1,
-            type="t",
-            hostname="h",
-            payload=None,
-            fields=[
-                Field(
-                    name="content",
-                    value_string=None,
-                    # impossible unicode byte sequence
-                    # http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
-                    value_bytes=['\xfe\xfe\xff\xff'],
-                    value_type=1
-                )
-            ]
-        )
-        message_parser._parse_heka_record(Record(message))
+    expected = {
+        "meta": {
+            "Timestamp": 1,
+            "Type": "t",
+            "Hostname": "h",
+        }
+    }
+
+    parsed = message_parser._parse_heka_record(Record(message))
+
+    assert json.dumps(parsed) == json.dumps(expected)


### PR DESCRIPTION
[bug link](https://bugzilla.mozilla.org/show_bug.cgi?id=1447851)

Option b seemed like a good choice. Landfill messages will be parsed directly into a string, which can be later decoded using `json.loads` if needed. 