### PR TITLE
Bug 1463877 - partition strategy

### DIFF
--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -43,6 +43,7 @@ def _group_by_size_greedy(obj_list, tot_groups):
 
 
 def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
+<<<<<<< HEAD
     """Partition a list of objects evenly and by file size
 
     Files are placed according to largest file in the smallest bucket. If the
@@ -55,6 +56,10 @@ def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
     """
     sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
     groups = [(random.random(), []) for _ in range(tot_groups)]
+=======
+    sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
+    groups = [(0, []) for _ in range(tot_groups)]
+>>>>>>> dfc73a9... improve style
 
     if tot_groups <= 1:
         groups = _group_by_size_greedy(obj_list, tot_groups)

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -259,7 +259,7 @@ class Dataset:
         keys = sc.parallelize(scanned).flatMap(self.store.list_keys)
         return keys.take(limit) if limit else keys.collect()
 
-    def records(self, sc, group_by, limit=None, sample=1, seed=42, decode=None, summaries=None):
+    def records(self, sc, group_by='greedy', limit=None, sample=1, seed=42, decode=None, summaries=None):
         """Retrieve the elements of a Dataset
 
         :param sc: a SparkContext object

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -43,7 +43,6 @@ def _group_by_size_greedy(obj_list, tot_groups):
 
 
 def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
-<<<<<<< HEAD
     """Partition a list of objects evenly and by file size
 
     Files are placed according to largest file in the smallest bucket. If the
@@ -56,10 +55,6 @@ def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
     """
     sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
     groups = [(random.random(), []) for _ in range(tot_groups)]
-=======
-    sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
-    groups = [(0, []) for _ in range(tot_groups)]
->>>>>>> dfc73a9... improve style
 
     if tot_groups <= 1:
         groups = _group_by_size_greedy(obj_list, tot_groups)

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -50,7 +50,7 @@ def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
     by itself.
     :param obj_list: a list of dict-like objects with a 'size' property
     :param tot_groups: number of partitions to split the data
-    :threshold: the maximum size of each bucket
+    :param threshold: the maximum size of each bucket
     :return: a list of lists, one for each partition
     """
     sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -43,35 +43,28 @@ def _group_by_size_greedy(obj_list, tot_groups):
 
 
 def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
-    sub_list = []
-    groups = []
-    priority = []
-    tmp_object = None
-    sub_list_size = 0
+    groups = [[]]
+    sorted_obj_list = []
+    best_partition = None
 
     if tot_groups <= 1:
         groups = _group_by_size_greedy(obj_list, tot_groups)
         return groups
-
-    for obj in obj_list:
-        for key in obj:
-            priority.append((obj[key], obj))
-
-    heapq.heapify(priority)
-    while priority:
-        tmp_object = heapq.heappop(priority)
-
-        if tmp_object[0] >= threshold:
-            groups.append(tmp_object)
-
-        sub_list.append(tmp_object)
-        sub_list_size += tmp_object[0]
-        if sub_list_size >= threshold:
-            groups.append(sub_list)
-            sub_list = []
-            sub_list_size = 0
-    if sub_list:
-        groups.append(sub_list)
+    sorted_obj_list = [(obj['size'], obj) for obj in obj_list]
+    sorted_obj_list.sort(reverse=True)
+    groups = [(0, []) for _ in range(tot_groups)]
+    heapq.heapify(groups)
+    for obj in sorted_obj_list:
+        if obj[0] > threshold:
+            heapq.heappush(groups, (obj[0], [obj[1]]))
+        else:
+            best_partition = heapq.heappop(groups)
+            (size, files) = best_partition
+            size += obj[0]
+            files.append(obj[1])
+            best_partition = (size, files)
+            heapq.heappush(groups, best_partition)
+    groups = [group[1] for group in groups]
     return groups
 
 

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -3,6 +3,7 @@
 # file, you can obtain one at http://mozilla.org/MPL/2.0/.
 from __future__ import division, print_function
 import functools
+import heapq
 import json
 import random
 import re
@@ -38,6 +39,39 @@ def _group_by_size_greedy(obj_list, tot_groups):
     for index, obj in enumerate(sorted_list):
         current_group = groups[index % len(groups)]
         current_group.append(obj)
+    return groups
+
+
+def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
+    sub_list = []
+    groups = []
+    priority = []
+    tmp_object = None
+    sub_list_size = 0
+
+    if tot_groups <= 1:
+        groups = _group_by_size_greedy(obj_list, tot_groups)
+        return groups
+
+    for obj in obj_list:
+        for key in obj:
+            priority.append((obj[key], obj))
+
+    heapq.heapify(priority)
+    while priority:
+        tmp_object = heapq.heappop(priority)
+
+        if tmp_object[0] >= threshold:
+            groups.append(tmp_object)
+
+        sub_list.append(tmp_object)
+        sub_list_size += tmp_object[0]
+        if sub_list_size >= threshold:
+            groups.append(sub_list)
+            sub_list = []
+            sub_list_size = 0
+    if sub_list:
+        groups.append(sub_list)
     return groups
 
 

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -54,7 +54,7 @@ def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
     :return: a list of lists, one for each partition
     """
     sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
-    groups = [(0, []) for _ in range(tot_groups)]
+    groups = [(random.random(), []) for _ in range(tot_groups)]
 
     if tot_groups <= 1:
         groups = _group_by_size_greedy(obj_list, tot_groups)

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -312,9 +312,7 @@ class Dataset:
         elif group_by == 'greedy':
             groups = _group_by_size_greedy(summaries, 10*sc.defaultParallelism)
         else:
-            groups = _group_by_size_greedy(summaries, 10*sc.defaultParallelism)
-            raise Exception("This group_by method is invalid. Defaulting to
-            greedy")
+            raise Exception("group_by specification is invalid")
         rdd = sc.parallelize(groups, len(groups)).flatMap(lambda x: x)
 
         if decode is None:

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -310,9 +310,11 @@ class Dataset:
         if group_by == 'equal_size':
             groups = _group_by_equal_size(summaries, 10*sc.defaultParallelism)
         elif group_by == 'greedy':
-            groups = _group_by_size_greedy(summaries, 10 * sc.defaultParallelism)
+            groups = _group_by_size_greedy(summaries, 10*sc.defaultParallelism)
         else:
             groups = _group_by_size_greedy(summaries, 10*sc.defaultParallelism)
+            raise Exception("This group_by method is invalid. Defaulting to
+            greedy")
         rdd = sc.parallelize(groups, len(groups)).flatMap(lambda x: x)
 
         if decode is None:

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -43,6 +43,16 @@ def _group_by_size_greedy(obj_list, tot_groups):
 
 
 def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
+    """Partition a list of objects evenly and by file size
+
+    Files are placed according to largest file in the smallest bucket. If the
+    file is larger than the given threshold, then it is placed in a new bucket
+    by itself.
+    :param obj_list: a list of dict-like objects with a 'size' property
+    :param tot_groups: number of partitions to split the data
+    :threshold: the maximum size of each bucket
+    :return: a list of lists, one for each partition
+    """
     sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
     groups = [(0, []) for _ in range(tot_groups)]
 

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -267,6 +267,7 @@ class Dataset:
         """Retrieve the elements of a Dataset
 
         :param sc: a SparkContext object
+        :param group_by: specifies a partition strategy for the objects
         :param limit: maximum number of objects to retrieve
         :param decode: an optional transformation to apply to the objects retrieved
         :param sample: percentage of results to return. Useful to return a sample

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -259,7 +259,7 @@ class Dataset:
         keys = sc.parallelize(scanned).flatMap(self.store.list_keys)
         return keys.take(limit) if limit else keys.collect()
 
-    def records(self, sc, limit=None, sample=1, seed=42, decode=None, summaries=None):
+    def records(self, sc, group_by, limit=None, sample=1, seed=42, decode=None, summaries=None):
         """Retrieve the elements of a Dataset
 
         :param sc: a SparkContext object
@@ -302,7 +302,12 @@ class Dataset:
         total_size_mb = total_size / float(1 << 20)
         print("fetching %.5fMB in %s files..." % (total_size_mb, len(summaries)))
 
-        groups = _group_by_size_greedy(summaries, 10 * sc.defaultParallelism)
+        if group_by == 'equal_size':
+            groups = _group_by_equal_size(summaries, 10*sc.defaultParallelism)
+        elif group_by == 'greedy':
+            groups = _group_by_size_greedy(summaries, 10 * sc.defaultParallelism)
+        else:
+            groups = _group_by_size_greedy(summaries, 10*sc.defaultParallelism)
         rdd = sc.parallelize(groups, len(groups)).flatMap(lambda x: x)
 
         if decode is None:

--- a/moztelemetry/dataset.py
+++ b/moztelemetry/dataset.py
@@ -43,27 +43,21 @@ def _group_by_size_greedy(obj_list, tot_groups):
 
 
 def _group_by_equal_size(obj_list, tot_groups, threshold=pow(2, 32)):
-    groups = [[]]
-    sorted_obj_list = []
-    best_partition = None
+    sorted_obj_list = sorted([(obj['size'], obj) for obj in obj_list], reverse=True)
+    groups = [(0, []) for _ in range(tot_groups)]
 
     if tot_groups <= 1:
         groups = _group_by_size_greedy(obj_list, tot_groups)
         return groups
-    sorted_obj_list = [(obj['size'], obj) for obj in obj_list]
-    sorted_obj_list.sort(reverse=True)
-    groups = [(0, []) for _ in range(tot_groups)]
     heapq.heapify(groups)
     for obj in sorted_obj_list:
         if obj[0] > threshold:
             heapq.heappush(groups, (obj[0], [obj[1]]))
         else:
-            best_partition = heapq.heappop(groups)
-            (size, files) = best_partition
+            size, files = heapq.heappop(groups)
             size += obj[0]
             files.append(obj[1])
-            best_partition = (size, files)
-            heapq.heappush(groups, best_partition)
+            heapq.heappush(groups, (size, files))
     groups = [group[1] for group in groups]
     return groups
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,7 +9,8 @@ from concurrent import futures
 import pytest
 
 import moztelemetry
-from moztelemetry.dataset import Dataset, _group_by_size_greedy
+from moztelemetry.dataset import Dataset, _group_by_size_greedy,
+                                _group_by_equal_size
 from moztelemetry.store import InMemoryStore, S3Store
 
 
@@ -235,6 +236,28 @@ def test_group_by_size_greedy():
         [{'size': 4}, {'size': 1}],
         [{'size': 3}],
         [{'size': 2}]
+    ]
+
+
+def test_group_by_equal_size(): 
+    obj_list1 = [dict(size=i) for i in range(1, 5)]
+    obj_list2 = [{'size':70}, {'size':70}, {'size':70}, {'size':70}]
+    obj_list3 = [{'size':4}, {'size':1}, {'size':3}, {'size':2}]
+
+    groups = _group_by_equal_size(obj_list1, 1)
+    assert groups == [
+            [{'size': 4}, {'size': 3}, 
+            {'size': 2}, {'size': 1}]
+    ]
+    groups = _group_by_equal_size(obj_list2, 2, 100)
+    assert groups == [ 
+        [(70, {'size': 70}), (70, {'size': 70})], 
+        [(70, {'size': 70}), (70, {'size': 70})]
+    ]
+    groups = _group_by_equal_size(obj_list3, 3, 5)
+    assert groups == [
+        [(1, {'size': 1}), (2, {'size': 2}), (3, {'size': 3})], 
+        [(4, {'size': 4})]
     ]
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -239,24 +239,23 @@ def test_group_by_size_greedy():
     ]
 
 
-def test_group_by_equal_size(): 
+def test_group_by_equal_size():
     obj_list1 = [dict(size=i) for i in range(1, 5)]
-    obj_list2 = [{'size':70}, {'size':70}, {'size':70}, {'size':70}]
-    obj_list3 = [{'size':4}, {'size':1}, {'size':3}, {'size':2}]
+    obj_list2 = [{'size': 70}, {'size': 70}, {'size': 70}, {'size': 70}]
+    obj_list3 = [{'size': 4}, {'size': 1}, {'size': 3}, {'size': 2}]
 
     groups = _group_by_equal_size(obj_list1, 1)
     assert groups == [
-            [{'size': 4}, {'size': 3}, 
-            {'size': 2}, {'size': 1}]
+        [{'size': 4}, {'size': 3}, {'size': 2}, {'size': 1}]
     ]
     groups = _group_by_equal_size(obj_list2, 2, 100)
-    assert groups == [ 
-        [(70, {'size': 70}), (70, {'size': 70})], 
+    assert groups == [
+        [(70, {'size': 70}), (70, {'size': 70})],
         [(70, {'size': 70}), (70, {'size': 70})]
     ]
     groups = _group_by_equal_size(obj_list3, 3, 5)
     assert groups == [
-        [(1, {'size': 1}), (2, {'size': 2}), (3, {'size': 3})], 
+        [(1, {'size': 1}), (2, {'size': 2}), (3, {'size': 3})],
         [(4, {'size': 4})]
     ]
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -257,9 +257,9 @@ def test_group_by_equal_size():
     ]
     groups = _group_by_equal_size(obj_list3, 3, 5)
     assert groups == [
-        [{'size': 2}, {'size': 1}],
+        [{'size': 3}],
         [{'size': 4}],
-        [{'size': 3}]
+        [{'size': 2}, {'size': 1}]
     ]
     groups = _group_by_equal_size(obj_list4, 3, 5)
     assert groups == [

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,8 +9,8 @@ from concurrent import futures
 import pytest
 
 import moztelemetry
-from moztelemetry.dataset import Dataset, _group_by_size_greedy,
-                                _group_by_equal_size
+from moztelemetry.dataset import Dataset
+from moztelemetry.dataset import _group_by_size_greedy, _group_by_equal_size
 from moztelemetry.store import InMemoryStore, S3Store
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -243,8 +243,8 @@ def test_group_by_equal_size():
     obj_list1 = [dict(size=i) for i in range(1, 5)]
     obj_list2 = [{'size': 70}, {'size': 70}, {'size': 70}, {'size': 70}]
     obj_list3 = [{'size': 4}, {'size': 1}, {'size': 3}, {'size': 2}]
-    obj_list4 = [{'size':2}, {'size':2}, {'size':2}]
-    obj_list5 = [{'size':150}, {'size':70}, {'size':70}, {'size': 70}]
+    obj_list4 = [{'size': 2}, {'size': 2}, {'size': 2}]
+    obj_list5 = [{'size': 150}, {'size': 70}, {'size': 70}, {'size': 70}]
 
     groups = _group_by_equal_size(obj_list1, 1)
     assert groups == [
@@ -257,21 +257,22 @@ def test_group_by_equal_size():
     ]
     groups = _group_by_equal_size(obj_list3, 3, 5)
     assert groups == [
-        ['size': 2}, {'size': 1}],
+        [{'size': 2}, {'size': 1}],
         [{'size': 4}],
         [{'size': 3}]
     ]
     groups = _group_by_equal_size(obj_list4, 3, 5)
     assert groups == [
         [{'size': 2}],
-            [{'size': 2}],
-                [{'size': 2}]
+        [{'size': 2}],
+        [{'size': 2}]
     ]
     groups = _group_by_equal_size(obj_list5, 2, 100)
     assert groups == [
         [{'size': 70}],
-            [{'size':150}],
-                [{'size': 70}, {'size': 70}]
+        [{'size': 150}],
+        [{'size': 70}, {'size': 70}]
+    ]
 
 
 @pytest.mark.slow

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -243,6 +243,8 @@ def test_group_by_equal_size():
     obj_list1 = [dict(size=i) for i in range(1, 5)]
     obj_list2 = [{'size': 70}, {'size': 70}, {'size': 70}, {'size': 70}]
     obj_list3 = [{'size': 4}, {'size': 1}, {'size': 3}, {'size': 2}]
+    obj_list4 = [{'size':2}, {'size':2}, {'size':2}]
+    obj_list5 = [{'size':150}, {'size':70}, {'size':70}, {'size': 70}]
 
     groups = _group_by_equal_size(obj_list1, 1)
     assert groups == [
@@ -250,14 +252,26 @@ def test_group_by_equal_size():
     ]
     groups = _group_by_equal_size(obj_list2, 2, 100)
     assert groups == [
-        [(70, {'size': 70}), (70, {'size': 70})],
-        [(70, {'size': 70}), (70, {'size': 70})]
+        [{'size': 70}, {'size': 70}],
+        [{'size': 70}, {'size': 70}]
     ]
     groups = _group_by_equal_size(obj_list3, 3, 5)
     assert groups == [
-        [(1, {'size': 1}), (2, {'size': 2}), (3, {'size': 3})],
-        [(4, {'size': 4})]
+        ['size': 2}, {'size': 1}],
+        [{'size': 4}],
+        [{'size': 3}]
     ]
+    groups = _group_by_equal_size(obj_list4, 3, 5)
+    assert groups == [
+        [{'size': 2}],
+            [{'size': 2}],
+                [{'size': 2}]
+    ]
+    groups = _group_by_equal_size(obj_list5, 2, 100)
+    assert groups == [
+        [{'size': 70}],
+            [{'size':150}],
+                [{'size': 70}, {'size': 70}]
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Could I get some feedback on these changes? This method groups files into equally sized groups, as an alternative to the greedy strategy.

The method passes the unit tests. Next step is to test it against the benchmark tests after it is included.