### PR TITLE
Deploy a universal wheel for both Python 2 and Python 3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,7 @@ omit =
     moztelemetry/shared_telemetry_utils.py,
     moztelemetry/parse_histograms.py,
     moztelemetry/heka/message_pb2.py
+
+[bdist_wheel]
+# See https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels
+universal=1


### PR DESCRIPTION
After tagging and watching this project appear on PyPI, I noticed that the produced wheel distribution is python 3 only:
https://pypi.org/project/python_moztelemetry/0.10.1/#files

But this project natively supports 2 and 3, so we should upload a universal wheel.