### PR TITLE
Use a named docker volume for tox cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 
 .*
 *.egg*
+**/__pycache__/
+**.pyc
+**.pyo

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ of these docs. Be aware that you will need to have a working
 installation of Java and libsnappy, likely via your OS's package
 manager (i.e. `brew install snappy` on MacOS).
 
-If you're receiving mysterious errors, try removing cached files:
+If you're receiving mysterious errors, try removing cached files via:
 
-    find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
-    rm -r .*tox/
+    ./bin/clean

--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Remove various cached files that are intended to improve performance
+# but can cause errors as the environment evolves.
+
+# Move to the root of the git repository.
+cd $(git rev-parse --show-toplevel)
+
+# Clean all python cache files.
+find moztelemetry/ tests/ | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+
+# Remove any local tox environments.
+rm -rf .*tox/
+
+# Delete the docker volume we use for caching tox environment.
+docker volume rm moztelemetry-tox

--- a/bin/test
+++ b/bin/test
@@ -8,22 +8,23 @@ cd $(git rev-parse --show-toplevel)
 
 # Set default variables if not already present in the environment.
 : ${PYTHON_VERSION:=3.6}
-: ${TOXDIR:=.dockertox}  # Prevents the circleci cli from picking up the env
 : ${TOXENV:="py${PYTHON_VERSION/./}"}
 
 # Set some derived variables.
 TOXENV="py${PYTHON_VERSION/./}"
 
-# Clean all python cache files, since they may confuse the docker environment.
-find moztelemetry/ tests/ | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
+# Create a named volume to hold cached tox environment between runs;
+# this can cause errors with running tests after modifying setup.py, etc.,
+# so be prepared to run the bin/clean script.
+docker volume create moztelemetry-tox
 
 # If nothing has changed, this build step will hit cache and run quickly.
 docker build -t moztelemetry:"$TOXENV" --build-arg PYTHON_VERSION="$PYTHON_VERSION" .
 
 # We mount the current directory to the container and run tox inside it.
 docker run -it --rm \
-       --volume "$(pwd)/$TOXDIR":/python_moztelemetry/"$TOXDIR" \
-       --volume "$(pwd)"/.git:/python_moztelemetry/.git \
+       --mount source=moztelemetry-tox,target=/python_moztelemetry/.tox \
+       --mount type=bind,source="$(pwd)"/.git,target=/python_moztelemetry/.git,readonly \
        --workdir /python_moztelemetry \
        moztelemetry:"$TOXENV" \
-       tox --workdir "$TOXDIR" -e "$TOXENV" -- $@
+       tox -e "$TOXENV" -- $@

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,12 @@ usedevelop = True
 extras = testing
 commands = pytest {posargs:tests/}
 
+# 2018-09-14: moto isn't working with latest boto3, so we need to pin version for tests;
+# see https://github.com/spulec/moto/pull/1801
+# TODO: Remove this once moto restores compatibility
+deps =
+    boto3==1.7.84
+
 [testenv:lint]
 deps =
     flake8


### PR DESCRIPTION
This should avoid the problem of files being created with root ownership on Linux hosts.