### PR TITLE
Pass expected argument to --cov

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ addopts =
     --tb=native
     --timeout=120
     --capture=no
-    --cov
+    --cov=moztelemetry
 
 [testenv]
 skipsdist = True


### PR DESCRIPTION
`./bin/test tests/heka/` was running all tests rather than just those in the
target directory because `--cov` was eating the directory, assuming it was
the argument of where we should do code coverage.